### PR TITLE
Add a custom view by username (#91)

### DIFF
--- a/nrm_django/grants/admin.py
+++ b/nrm_django/grants/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import path
+from django.shortcuts import render
 
 from .models import Grant, GrantAuthority, Note
 
@@ -140,6 +142,17 @@ class GrantAdmin(admin.ModelAdmin):
             },
         ),
     )
+
+    def get_urls(self):
+        urls = super().get_urls()
+        my_urls = [
+            path('my_view/', self.admin_site.admin_view(self.my_view)),
+        ]
+        return my_urls + urls 
+
+    def my_view(self, request):
+        """Just a view that does nothing yet."""
+        return render(request, "grants/index.html", {"context_key": "data"})
 
 
 admin.site.register(Grant, GrantAdmin)

--- a/nrm_django/grants/admin.py
+++ b/nrm_django/grants/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.urls import path
 from django.views.generic.list import ListView
-from django.shortcuts import render
 
 from .models import Grant, GrantAuthority, Note
 
@@ -147,9 +146,11 @@ class GrantAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super().get_urls()
         my_urls = [
-            path('my_view/<username>', self.admin_site.admin_view(CustomView.as_view())),
+            path(
+                "my_view/<username>", self.admin_site.admin_view(CustomView.as_view())
+            ),
         ]
-        return my_urls + urls 
+        return my_urls + urls
 
 
 class CustomView(ListView):
@@ -157,7 +158,11 @@ class CustomView(ListView):
     template_name = "grants/index.html"
 
     def get_queryset(self):
-        return Grant.objects.filter(created_by=self.kwargs.get("username")).values("cn", "proj_title", "status").order_by("-status_date")
+        return (
+            Grant.objects.filter(created_by=self.kwargs.get("username"))
+            .values("cn", "proj_title", "status")
+            .order_by("-status_date")
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/nrm_django/nrm_app/static/css/site.css
+++ b/nrm_django/nrm_app/static/css/site.css
@@ -1,3 +1,10 @@
 .usa-hero{
     background-image:url("/static/vendor/uswds-2.10.1/img/hero.png");
 }
+
+.beta-banner {
+    background-color: #FFE396;
+    color: #122D52;
+    margin: auto 0;
+    padding: 0.1rem 0;
+}

--- a/nrm_django/nrm_app/templates/base.html
+++ b/nrm_django/nrm_app/templates/base.html
@@ -56,6 +56,11 @@
 <body id="{% block bodyid %}default{% endblock %}" class="{% block bodyclass %}{% endblock %}">
   <header class="usa-header usa-header--extended" role="banner">
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+    <section class="beta-banner">
+        <div class="grid-container">
+        <p class="grid-col-auto"><strong>BETA SITE:</strong> We are developing a new Grants Management application.</p>
+        </div>
+    </section>
     {% include "includes/header.html" %}
     {% block navigation %}{% endblock navigation %}
   </header>

--- a/nrm_django/nrm_app/templates/grants/index.html
+++ b/nrm_django/nrm_app/templates/grants/index.html
@@ -2,5 +2,15 @@
 {% load static %}
 
 {% block main %}
-{{ context_key }}
+
+<h1>Grants created by user {{ username }}</h1>
+
+<ul>
+{% for grant in object_list %}
+    <li><a href="/admin/grants/grant/{{ grant.cn }}">{{ grant.cn }}</a> - {{ grant.proj_title }} ({{ grant.status }})</li>
+{% empty %}
+    <li>No grants created by that user.</li>
+{% endfor %}
+</ul>
+
 {% endblock %}

--- a/nrm_django/nrm_app/templates/grants/index.html
+++ b/nrm_django/nrm_app/templates/grants/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block main %}
+{{ context_key }}
+{% endblock %}

--- a/nrm_django/nrm_site/settings/dev.py
+++ b/nrm_django/nrm_site/settings/dev.py
@@ -1,0 +1,13 @@
+
+"""Dev allows localhost access, and DATABASE_URL environment variable."""
+
+import os
+
+import dj_database_url
+
+from .base import *  # noqa
+
+database_url = os.getenv("DATABASE_URL")
+if database_url:  # if specified in the environment
+    DATABASES = {"default": dj_database_url.parse(database_url)}
+ALLOWED_HOSTS = ["127.0.0.1"]

--- a/nrm_django/nrm_site/settings/dev.py
+++ b/nrm_django/nrm_site/settings/dev.py
@@ -1,4 +1,3 @@
-
 """Dev allows localhost access, and DATABASE_URL environment variable."""
 
 import os


### PR DESCRIPTION
This adds a custom Django view at `/admin/grants/grant/my_view/USERNAME` that shows just a very simple clickable list of all of the grants that were created by a particular username. This is a first step towards a useful "spreadsheet" view that would replicate what an individual grants specialist might use to track agreements that they are involved in. 

Resolves #91

<img width="860" alt="Screen Shot 2021-03-15 at 11 27 13" src="https://user-images.githubusercontent.com/443389/111198297-66696c00-858d-11eb-95a4-b65e1a2e3a20.png">
