### PR TITLE
Carefully select category choices when needed

### DIFF
--- a/nrm_django/grants/forms.py
+++ b/nrm_django/grants/forms.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError
 from .models import Category, Grant
 from contacts.models import AccomplishmentInstrument, Contact
 
-cat_set = Category.objects.order_by("category_desc").distinct("category_desc")
 instance_id = "10602"
 
 
@@ -96,6 +95,8 @@ class GrantUpdateForm(forms.ModelForm):
     # The actual queryset gets set down below in `init`
     # TO-DO: Ideally we would migrate to Categories being just a list of cats,
     # with Grant having an FK to that table, so we could avoid these sorts of shenanigans.
+    cat_set = Category.objects.order_by("category_desc").distinct("category_desc")
+
     project_category = forms.ModelChoiceField(
         label="Project category",
         queryset=cat_set,
@@ -119,7 +120,6 @@ class GrantUpdateForm(forms.ModelForm):
         # If we're modifying an existing instance we'll need to manually
         # set the initial value for org, because we don't have an FK on Grant
         if self.instance:
-            print("self instance org is", self.instance.org)
             self.fields["org_select"].initial = self.instance.org
 
         # We'll also need to set the initial project_category.
@@ -129,8 +129,14 @@ class GrantUpdateForm(forms.ModelForm):
             try:
                 this_cat = Category.objects.get(grant=self.instance)
                 # if we dropped this cat becuase of the distinct() on cat_set, we need to add it back in:
-                if this_cat not in cat_set:
-                    cat_set.append(this_cat)
+                if this_cat not in self.cat_set:
+                    # there is a category in cat_set with this_cat's same
+                    # category_desc. Swap that one out for this one.
+                    cat_ids = [cat.cn for cat in self.cat_set]
+                    replace_me = Category.objects.filter(cn__in=cat_ids, category_desc=this_cat.category_desc).first().cn
+                    cat_ids[cat_ids.index(replace_me)] = this_cat.cn
+                    # reconstruct the queryset
+                    self.cat_set = Category.objects.filter(cn__in=cat_ids)
                 self.fields["project_category"].initial = this_cat.cn
             except Category.DoesNotExist:
                 pass

--- a/nrm_django/grants/forms.py
+++ b/nrm_django/grants/forms.py
@@ -133,7 +133,13 @@ class GrantUpdateForm(forms.ModelForm):
                     # there is a category in cat_set with this_cat's same
                     # category_desc. Swap that one out for this one.
                     cat_ids = [cat.cn for cat in self.cat_set]
-                    replace_me = Category.objects.filter(cn__in=cat_ids, category_desc=this_cat.category_desc).first().cn
+                    replace_me = (
+                        Category.objects.filter(
+                            cn__in=cat_ids, category_desc=this_cat.category_desc
+                        )
+                        .first()
+                        .cn
+                    )
                     cat_ids[cat_ids.index(replace_me)] = this_cat.cn
                     # reconstruct the queryset
                     self.cat_set = Category.objects.filter(cn__in=cat_ids)


### PR DESCRIPTION
The data model for categories is strange and makes it hard to select a list of distinct categories for use in a select box on a web form. This fixes an error we had made when trying to do this initially. It is likely not very performant because it has to evaluate a queryset, manipulate a list of primary keys, and then construct a new queryset, but I couldn't find an easier way to add things onto a Django queryset which is using `.distinct()`.

Should fix #244 