### PR TITLE
Customizable search description

### DIFF
--- a/nrm_django/grants/admin.py
+++ b/nrm_django/grants/admin.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 
+from nrm_app.admin import NRMAdmin
+
 from .models import Grant, GrantAuthority, Note
 
 
-class GrantAdmin(admin.ModelAdmin):
+class GrantAdmin(NRMAdmin):
     # list options
     list_display = (
         "resolved_id",
@@ -20,6 +22,7 @@ class GrantAdmin(admin.ModelAdmin):
         "application_id",
         "applicant_name",
     ]
+    search_description = "You can search by project title, description, cooperator name, agreement number or application ID"
 
 
 class GrantAuthorityAdmin(admin.ModelAdmin):

--- a/nrm_django/nrm_app/admin.py
+++ b/nrm_django/nrm_app/admin.py
@@ -1,3 +1,20 @@
-# from django.contrib import admin
+from django.contrib import admin
 
 # Register your models here.
+
+
+class NRMAdmin(admin.ModelAdmin):
+    def get_search_description(self):
+        try:
+            desc = self.search_description
+        except AttributeError:
+            return ""
+        return desc
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["search_description"] = self.get_search_description()
+        return super().changelist_view(
+            request,
+            extra_context=extra_context,
+        )

--- a/nrm_django/nrm_app/admin.py
+++ b/nrm_django/nrm_app/admin.py
@@ -4,6 +4,9 @@ from django.contrib import admin
 
 
 class NRMAdmin(admin.ModelAdmin):
+
+    """Extra context added to the default ModelAdmin."""
+
     def get_search_description(self):
         try:
             desc = self.search_description

--- a/nrm_django/nrm_app/templatetags/search_form.py
+++ b/nrm_django/nrm_app/templatetags/search_form.py
@@ -1,0 +1,28 @@
+from django import template
+
+from django.contrib.admin.templatetags.admin_list import search_form
+from django.contrib.admin.templatetags.base import InclusionAdminNode
+
+register = template.Library()
+
+
+def this_search_form(cl, description):
+    orig = search_form(cl)
+    orig["search_description"] = description
+    return orig
+
+
+@register.tag(name="search_form")
+def search_form_with_description_tag(parser, token):
+    """
+    Duplicates the search_form template tag from django.contrib.admin.templatetags
+
+    But with a description that can be passed in.
+    """
+    return InclusionAdminNode(
+        parser,
+        token,
+        func=this_search_form,
+        template_name="search_form.html",
+        takes_context=False,
+    )

--- a/nrm_django/nrm_site/templates/admin/change_list.html
+++ b/nrm_django/nrm_site/templates/admin/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls static admin_list %}
+{% load i18n admin_urls static admin_list search_form %}
 
 {% block extrastyle %}
 {{ block.super }}
@@ -68,7 +68,7 @@
     {% endif %}
     <div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
         <div class="changelist-form-container">
-            {% block search %}{% search_form cl %}{% endblock %}
+            {% block search %}{% search_form cl search_description %}{% endblock %}
             {% block date_hierarchy %}{% if cl.date_hierarchy %}{% date_hierarchy cl %}{% endif %}{% endblock %}
 
             <form id="changelist-form" method="post" {% if cl.formset and cl.formset.is_multipart %}

--- a/nrm_django/nrm_site/templates/admin/search_form.html
+++ b/nrm_django/nrm_site/templates/admin/search_form.html
@@ -2,7 +2,7 @@
 {% if cl.search_fields %}
 <div id="toolbar"><form id="changelist-search" method="get">
 <div><!-- DIV needed for valid HTML -->
-    <p>You can search by project title, description, cooperator name, agreement number or application ID.</p>
+    <p>{{ search_description }}</p>
     <label for="searchbar"><img src="{% static 'admin/img/search.svg' %}" alt="Search"></label>
 <input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
 <input type="submit" value="{% translate 'Search' %}">


### PR DESCRIPTION
We used custom text ion the search box template to help with the grants and agreements search, but that didn't work right when searching for users. This makes that search text customizable at the model level to close #230.

<img width="607" alt="Screen Shot 2021-06-11 at 14 23 37" src="https://user-images.githubusercontent.com/443389/121739058-b4283e80-cac0-11eb-8cb6-151c178a11d0.png">

<img width="660" alt="Screen Shot 2021-06-11 at 14 23 54" src="https://user-images.githubusercontent.com/443389/121739076-bb4f4c80-cac0-11eb-8349-3b7d8d574bf9.png">

It required overriding one of the Django admin's template tags to pass in another variable, but that pattern is probably generally useful and the actual use of it in `grants/admin.py` is straightforward.