### PR TITLE
234 set certain dates to today

### DIFF
--- a/nrm_django/grants/templates/includes/field.html
+++ b/nrm_django/grants/templates/includes/field.html
@@ -14,7 +14,16 @@
     <p class="usa-hint">{{ field.help_text|safe }}</p>
   {% endif %}
   {# data-default-value is just used by the date picker but is harmless for other inputs #}
-  <div class="{{ field|widget_type }} {{ parent_class }}" data-default-value="{{ field.value|date:'Y-m-d' }}">
+  {% if field.value %}
+    {# if there is a value given, we'll use it #}
+    <div class="{{ field|widget_type }} {{ parent_class }}" data-default-value="{{ field.value|date:'Y-m-d' }}">
+  {% elif default_now_if_empty %} 
+    {# If we've said we want to default to now, we'll do that #}
+    <div class="{{ field|widget_type }} {{ parent_class }}" data-default-value="{% now 'Y-m-d' %}">
+  {% else %}
+    {# otherwise we want no default, just go #}
+    <div class="{{ field|widget_type }} {{ parent_class }}">
+  {% endif %}
     {% if field.errors %}
       {{ field|add_class:"usa-input usa-input--error" }}
     {% else %}

--- a/nrm_django/grants/templates/includes/min_form.html
+++ b/nrm_django/grants/templates/includes/min_form.html
@@ -1,7 +1,7 @@
 {% include "includes/field.html" with field=form.proj_title %}
 {% include "includes/field.html" with field=form.proj_desc %}
-{% include "includes/field.html" with field=form.app_submit_date parent_class="usa-date-picker" %}
-{% include "includes/field.html" with field=form.app_received_date parent_class="usa-date-picker" %}
+{% include "includes/field.html" with field=form.app_submit_date parent_class="usa-date-picker" default_now_if_empty=True %}
+{% include "includes/field.html" with field=form.app_received_date parent_class="usa-date-picker" default_now_if_empty=True %}
 {% include "includes/field.html" with field=form.proposed_start_date parent_class="usa-date-picker" %}
 {% include "includes/field.html" with field=form.proposed_end_date parent_class="usa-date-picker" %}
 {% include "includes/field.html" with field=form.progrm_responsibility_type %}


### PR DESCRIPTION
Resolves #234 by defaulting certain dates to today.

Normally I'd probably use `firstof field.value now` but 
1. We need more granular control, since we only want to have certain fields default to today
2. There were questions about a template tag inside a template tag.

So I went with a cascading if/else thing.