### PR TITLE
Fix "multiple default values" error in migration

### DIFF
--- a/nrm_django/grants/migrations/0007_auto_20210323_1321.py
+++ b/nrm_django/grants/migrations/0007_auto_20210323_1321.py
@@ -39,7 +39,6 @@ class Migration(migrations.Migration):
             name="id",
             field=models.AutoField(
                 auto_created=True,
-                default=1,
                 primary_key=True,
                 serialize=False,
                 verbose_name="ID",


### PR DESCRIPTION
When migrating a fresh project, I received this error:

> psycopg2.errors.SyntaxError: multiple default values specified for column "id" of table "ii_ga_authorities"

It seems as if specifying an explicit default and setting a column as a primary key are in conflict. Removing the `default=1` line allowed the migration to proceed.