### PR TITLE
ADR 1: Documenting decision to use open-source USDA/FS repo

### DIFF
--- a/decisions/architecture/001-use-open-source-repository.md
+++ b/decisions/architecture/001-use-open-source-repository.md
@@ -1,0 +1,53 @@
+# 1. Use an open-source repository
+
+Status: accepted (retrospect) \
+Date: [28 April 2021](https://github.com/USDAForestService/NRM-Grants-Agreements/issues/141#event-4657973222)
+
+## Decision Outcome
+
+We decided to use an open-source GitHub code repository for the NRM G&A modernization.
+
+### Positive Consequences
+
+- Enacts the principle of doing public work in public.
+- Keeps the repository under Forest Service control (while staying open).
+- Aligns with the 18F [policy](https://github.com/18F/open-source-policy/blob/master/policy.md) of working in the open. See the policy for more on the benefits of working in the open.
+- Aligns with long-standing 18F [practice](https://18f.gsa.gov/tags/open-source/) of working in the open.
+- Facilitates access to the repository for new team members and avoids a costly wait for USDA onboarding.
+- Avoids all costs associated with cloud-hosted CI/CD platforms such as CircleCI and GitHub Actions.
+
+### Negative Consequences
+(None apparent.)
+
+
+## Options Considered
+
+### [Option] Use a private repository
+
+#### Pros
+(None apparent that are exclusive to this option.)
+
+#### Cons
+- Prevents developing in the open.
+
+
+## Decision Makers
+
+### Accountable
+- Jay Berg (Product Owner, USFS)
+
+### Responsible
+- Neil Martinsen-Burrell (18F)
+- Melissa Braxton (18F)
+
+### Consulted
+- Carter Baxter (18F)
+
+### Informed
+- Chaochung Tsai (USFS)
+
+
+## Decision History
+
+- Proposed: [22 Mar 2021](https://github.com/USDAForestService/NRM-Grants-Agreements/issues/141#issue-837963581)
+- Accepted: [28 April 2021](https://github.com/USDAForestService/NRM-Grants-Agreements/issues/141#event-4657973222)


### PR DESCRIPTION
This ADR is to document a decision made back in April—the Decision History contains links to the relevant issue, #141.

@jayrbergjr Just tagging you as an FYI, no action needed. This decision is being marked as "accepted (in retrospect)" given your involvement in #141. Expecting this to be the only retrospect ADR.