### PR TITLE
Get frontend tests working and passing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,18 @@
 # Set deployment variables in CircleCI as environment variables
 version: 2
 
+install-node-dependencies: &install-node-dependencies
+  run:
+    name: Node install
+    working_directory: ~/project
+    command: npm ci
+
+install-node-frontend-deps: &install-node-frontend-deps
+  run:
+    name: Node install
+    working_directory: ~/project/frontend
+    command: npm ci
+
 install-python-dependencies: &install-python-dependencies
   run:
     name: Install python dependencies
@@ -42,10 +54,8 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: Node install
-          working_directory: ~/project
-          command: npm ci
+      - *install-node-dependencies
+      - *install-node-frontend-deps
       - *install-python-dependencies
       - *install-python-dev-dependencies
       - run:
@@ -73,6 +83,11 @@ jobs:
           working_directory: ~/project/nrm_django
           command: |
             pipenv run python manage.py migrate --settings=nrm_site.settings.test
+      - run:
+          name: "[frontend] Run spec"
+          working_directory: ~/project/frontend
+          command: |
+            npm run test
       - run:
           name: Run unit tests & check coverage
           working_directory: ~/project/nrm_django

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,1 @@
+src/test.ts

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve --host 0.0.0.0 --port 4200",
     "build": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test --watch=false"
   },
   "private": true,
   "dependencies": {

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -14,18 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'frontend'`, () => {
+  it(`should have as title 'NRM G&A'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('frontend');
+    expect(app.title).toEqual('NRM G&A');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain(
-      'frontend app is running!'
-    );
+    expect(compiled.querySelector('h1')?.textContent).toContain('NRM');
   });
 });

--- a/frontend/src/app/grant.service.spec.ts
+++ b/frontend/src/app/grant.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { GrantService } from './grant.service';
 
@@ -5,7 +6,10 @@ describe('GrantService', () => {
   let service: GrantService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [GrantService],
+    });
     service = TestBed.inject(GrantService);
   });
 

--- a/frontend/src/app/grants/grants.component.spec.ts
+++ b/frontend/src/app/grants/grants.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { GrantsComponent } from './grants.component';
 
@@ -7,6 +8,7 @@ describe('GrantsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       declarations: [GrantsComponent],
     }).compileComponents();
   });

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,11 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
+import 'zone.js/testing'; // This MUST be the first import in the list.
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
-import 'zone.js/testing';
 
 declare const require: {
   context(


### PR DESCRIPTION
- Fixes broken baseline tests
- Adds .prettierignore to ensure that an import whose order is important doesn't get reordered
- Adds frontend tests to CI config